### PR TITLE
Add cloudbuild.yaml for deployment.

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,12 @@
+steps:
+- name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+  args:
+  - gcloud
+  - functions
+  - deploy
+  - delete_unattached_pds
+  - --region=us-central1
+  - --source=.
+  - --trigger-http
+  - --runtime=python310
+  dir: 'unattached-pd'


### PR DESCRIPTION
Initial version of cloudbuild.yaml which tells Cloud Build how to deploy the `delete_unattached_pds` Cloud Function.

Linted with `cloud-build-local`, https://cloud.google.com/build/docs/build-debug-locally#build_locally

Ref doc, https://cloud.google.com/build/docs/deploying-builds/deploy-functions